### PR TITLE
Add CLI parameter to specify file suffix

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ export function run(args: minimist.ParsedArgs, opts?: TRunOptions) {
   if (!args._.length) {
     // tslint:disable-next-line:no-console
     console.error('missing path argument');
-    console.error('USAGE: jest-test-gen <path-to-file> --outputDir ./my/custom/output')
+    console.error('USAGE: jest-test-gen <path-to-file> --outputDir ./my/custom/output --fileSuffix .generated.test')
     process.exit(1);
   }
 
@@ -32,7 +32,11 @@ export function run(args: minimist.ParsedArgs, opts?: TRunOptions) {
       finalOutputDir = path.resolve(finalOutputDir, args.outputDir);
     }
   }
-  const specFileName = path.join(finalOutputDir,`${inputFilenameNoExt}.generated.test${inputFileExtension}`);
+  let fileSuffix = '.generated.test';
+  if (args.fileSuffix) {
+    fileSuffix = args.fileSuffix;
+  }
+  const specFileName = path.join(finalOutputDir,`${inputFilenameNoExt}${fileSuffix}${inputFileExtension}`);
 
   const sourceCode = readFileSync(inputPath).toString();
 


### PR DESCRIPTION
We sometimes don't want to use the default '.generated.test' and instead we want for example to use simply '-test'. This new parameter `fileSuffix` (just a suggestion, happy to change it) allows to specify a string to append to the file name before the file extension. By default this file suffix is '.generated.test'.